### PR TITLE
Removed np.float_ [UNTESTED]

### DIFF
--- a/sistr/src/writers.py
+++ b/sistr/src/writers.py
@@ -46,8 +46,6 @@ def to_dict(x, depth, exclude_keys=set(), depth_threshold=8):
         return int(x)
     if isinstance(x, np.int64):
         return int(x)
-    if isinstance(x, np.float_):
-        return float(x)
     if isinstance(x, np.float64):
         return float(x)
     if isinstance(x, np.bool_):


### PR DESCRIPTION
On some systems, sistr_cmd installed through conda/micromamba yields this error occurs:

> .local/lib/python3.12/site-packages/numpy/__init__.py", line 778, in __getattr__
>     raise AttributeError(
> AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.

This is despite creating environment with NumPy < 2.0 (encountered with 1.26)

would `np.float64` catch all relevant instances if removing `np.float_`?